### PR TITLE
Reduce verbosity when generating Jupyter notebooks

### DIFF
--- a/generate-jupyter.sh
+++ b/generate-jupyter.sh
@@ -1,14 +1,13 @@
 #! /bin/sh
 
 dir=${1:-.}
-for i in $(find $dir -name "*.adoc" | grep pages ); do 
-    if grep ":page-jupyter:" $i; then   
-        echo "Generating Jupyter Notebook for $i: "
+for i in $(find $dir -name "*.adoc" | grep pages ); do
+    if grep "^:page-jupyter:" $i 1> /dev/null; then
+        echo -n "Generating Jupyter Notebook for $i... "
         ipynb=$(echo $i | sed 's/.*\/pages\///' )
         dir=$(dirname $ipynb)
         mkdir -p jupyter/$dir
-        echo "generating jupyter/$dir/$(basename $ipynb .adoc).ipynb..."
-        pwd
         asciidoctor -r asciidoctor-jupyter -b jupyter $i -o jupyter/$dir/$(basename $ipynb .adoc).ipynb
-    fi; 
+        echo "jupyter/$dir/$(basename $ipynb .adoc).ipynb generated!"
+    fi;
 done


### PR DESCRIPTION
#### Before

```
:page-jupyter: true
Generating Jupyter Notebook for examples/modules/csm/pages/ribs/index.adoc: 
generating jupyter/ribs/index.ipynb...
/home/guillaume/.cache/antora/collector/toolbox.git-e29454bdae6f43789bca9678a0f55990d4ff56d0
:page-jupyter: true
Generating Jupyter Notebook for examples/modules/csm/pages/sensor/index.adoc: 
generating jupyter/sensor/index.ipynb...
```

#### After

```
Generating Jupyter Notebook for examples/modules/csm/pages/sensor/index.adoc... jupyter/ribs/index.ipynb generated!
Generating Jupyter Notebook for examples/modules/csm/pages/t-beam/index.adoc... jupyter/sensor/index.ipynb generated!
```